### PR TITLE
FSA22V2-82: Add support for fetching all heros

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,11 +1,11 @@
 import '@/assets/fonts/Bangers/index.scss';
 import '@/assets/fonts/LeagueSpartan/index.scss';
 import '@/assets/scss/base.scss';
-import { getCharacterById } from '@/js/services/characterService.js';
+import { getCharactersAll } from '@/js/services/characterService.js';
 import renderCharacters from './views/renderCharacter';
 
 (async () => {
-  const { name: characterName } = await getCharacterById(70);
-  console.debug(`%cNa na na na na na na na na na na na na, ${characterName}!`, 'font-family: Menlo, monospace; color: yellow;"');
+  const allCharacters = await getCharactersAll();
+  console.debug(`%cPow! Bam! ${allCharacters.length} heroes and villains retrieved!`, 'font-family: Menlo, monospace; color: yellow;"');
   renderCharacters();
 })();

--- a/src/js/services/characterService.js
+++ b/src/js/services/characterService.js
@@ -8,3 +8,12 @@ export const getCharacterById = async (id) => {
     return [];
   }
 };
+
+export const getCharactersAll = async () => {
+  try {
+    return get(`${process.env.API_URL}/all`);
+  } catch (error) {
+    console.error(`Error fetching all characters: ${error.message}`);
+    return [];
+  }
+};

--- a/src/js/services/characterService.spec.js
+++ b/src/js/services/characterService.spec.js
@@ -1,5 +1,5 @@
 import { get } from '@/js/services/apiService';
-import { getCharacterById } from './characterService';
+import { getCharacterById, getCharactersAll } from './characterService';
 
 // Mock out our API service so we can test the character service in isolation.
 jest.mock('@/js/services/apiService');
@@ -23,6 +23,39 @@ describe('Character Service', () => {
 
       await getCharacterById(MOCK_CHARACTER_ID);
       expect(get).toHaveBeenLastCalledWith(expect.stringContaining(`${MOCK_CHARACTER_ID}`));
+    });
+  });
+
+  describe('getCharactersAll', () => {
+    // getCharactersAll was able to call the API, so the data came back fine.
+    describe('successful API call', () => {
+      const MOCK_CHARACTER_ARRAY = [
+        { name: 'Mock character one' },
+        { name: 'Mock character two' },
+      ];
+
+      it('returns an array of characters', async () => {
+        get.mockResolvedValueOnce(MOCK_CHARACTER_ARRAY);
+
+        const characters = await getCharactersAll();
+        expect(characters).toEqual(expect.arrayContaining(MOCK_CHARACTER_ARRAY));
+      });
+    });
+
+    // getCharactersAll wasn't able to access the API, so got an error message
+    describe('unsuccessful API call', () => {
+      let characters;
+      const MOCK_ERROR = 'Unable to get all characters!';
+      beforeAll(async () => {
+        get.mockImplementation(() => { throw new Error(MOCK_ERROR); });
+        characters = await getCharactersAll();
+      });
+      it('returns an empty array when errors are thrown', () => {
+        expect(characters).toMatchObject([]);
+      });
+      it('logs an error message when an error is thrown', async () => {
+        expect(console.error).toHaveBeenCalledWith(expect.stringContaining(MOCK_ERROR));
+      });
     });
   });
 


### PR DESCRIPTION
### Description
<!-- Add description of work done here -->
Create a function `getCharactersAll` that returns the entire Sparkhero API as an array. Additionally, use that array to determine how many items were returned, and insert that into a sneaky `console.debug` message. 

2 additional tests were written in the `characterServices.spec.js` file to confirm...
1.  that `getCharactersAll` does indeed return an array, and
2. that an error message is thrown if `getCharactersAll` can't complete. 


### Spec

See Story: [FSA22V2-82](https://sparkbox.atlassian.net/jira/software/c/projects/FSA22V2/boards/125?modal=detail&selectedIssue=FSA22V2-82)

### Validation
<!-- Delete anything irrelevant to this PR -->

* [x] This PR has code changes, and our linters still pass.
* [x] This PR affects production code, so it was browser tested (see below).
* [x] This PR has new code, so new tests were added or updated, and they pass.
* [x] The content of this PR requires documentation, so we added a detailed description of the component's purpose, requirements, quirks, and instructions for use by designers and developers. Along with accessibility information if pertinent.

#### To Validate

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
3. Pull down all related branches.
4. Confirm all tests pass.
<!-- Add additional validation steps here -->

<!--
For an example of good validation instructions, check out Bryan's Bouncy Ball PR at https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701.
-->

---

#### Browser Testing
<!--
The browser list should be tailored to specific engagement and client needs.
Delete if irrelevant to this issue
-->

#### Gold Level Support

In these browsers, behavior & design closely match original specifications. A user is able to access all content and functionality, including the usability of required assistive devices, such as keyboard and screenreader.

**macOS**

* [x] Safari (last 2 major versions)
* [x] Chrome (last 6 months)
* [x] Firefox (last 6 months)

**Windows**

* [ ] IE 11+
* [x] Chrome (last 6 months)
* [x] Firefox (last 6 months)
* [x] Edge 18

**Mobile**

* [x] Safari (last 2 major versions)
* [x] Android 7+
* [x] Samsung Browser (last year)
* [x] Chrome (last 6 months)
* [x] Firefox (last 6 months)


